### PR TITLE
feat: add shorthand flags to CLI commands

### DIFF
--- a/shapmonitor/cli/log.py
+++ b/shapmonitor/cli/log.py
@@ -23,11 +23,18 @@ def log_command(
     ],
     data_dir: Annotated[
         Path,
-        typer.Option(help="Directory for SHAP log storage.", envvar="SHAPMONITOR_DATA_DIR"),
+        typer.Option(
+            "--data-dir",
+            "-d",
+            help="Directory for SHAP log storage.",
+            envvar="SHAPMONITOR_DATA_DIR",
+        ),
     ] = Path("./shap_logs"),
     sample_rate: Annotated[
         float,
-        typer.Option(help="Fraction of rows to sample (0.0–1.0).", min=0.0, max=1.0),
+        typer.Option(
+            "--sample-rate", "-s", help="Fraction of rows to sample (0.0–1.0).", min=0.0, max=1.0
+        ),
     ] = 1.0,
     model_version: Annotated[
         str,
@@ -35,11 +42,11 @@ def log_command(
     ] = "v0",
     feature_names: Annotated[
         Optional[list[str]],
-        typer.Option("--feature-name", help="Feature name (repeat for multiple)."),
+        typer.Option("--feature-name", "-f", help="Feature name (repeat for multiple)."),
     ] = None,
     json_output: Annotated[
         bool,
-        typer.Option("--json", help="Output result as JSON."),
+        typer.Option("--json", "-j", help="Output result as JSON."),
     ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Enable debug logging.")] = False,
     quiet: Annotated[

--- a/shapmonitor/cli/report.py
+++ b/shapmonitor/cli/report.py
@@ -32,11 +32,18 @@ report_app = typer.Typer(no_args_is_help=True)
 def summary_command(
     data_dir: Annotated[
         Path,
-        typer.Option(help="Directory containing SHAP logs.", envvar="SHAPMONITOR_DATA_DIR"),
+        typer.Option(
+            "--data-dir",
+            "-d",
+            help="Directory containing SHAP logs.",
+            envvar="SHAPMONITOR_DATA_DIR",
+        ),
     ] = Path("./shap_logs"),
     period: Annotated[
         Optional[str],
-        typer.Option(help="Period spec, e.g. 'last-7d' or '2026-04-01..2026-04-08'."),
+        typer.Option(
+            "--period", "-p", help="Period spec, e.g. 'last-7d' or '2026-04-01..2026-04-08'."
+        ),
     ] = None,
     start: Annotated[
         Optional[datetime],
@@ -50,11 +57,11 @@ def summary_command(
     ] = None,
     top_k: Annotated[
         Optional[int],
-        typer.Option("--top-k", help="Show only top K features."),
+        typer.Option("--top-k", "-k", help="Show only top K features."),
     ] = None,
     json_output: Annotated[
         bool,
-        typer.Option("--json", help="Output result as JSON."),
+        typer.Option("--json", "-j", help="Output result as JSON."),
     ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
     quiet: Annotated[bool, typer.Option("--quiet", "-q")] = False,
@@ -130,15 +137,20 @@ def summary_command(
 def drift_command(
     data_dir: Annotated[
         Path,
-        typer.Option(help="Directory containing SHAP logs.", envvar="SHAPMONITOR_DATA_DIR"),
+        typer.Option(
+            "--data-dir",
+            "-d",
+            help="Directory containing SHAP logs.",
+            envvar="SHAPMONITOR_DATA_DIR",
+        ),
     ] = Path("./shap_logs"),
     ref: Annotated[
         Optional[str],
-        typer.Option("--ref", help="Reference period, e.g. 'last-14d..last-7d'."),
+        typer.Option("--ref", "-r", help="Reference period, e.g. 'last-14d..last-7d'."),
     ] = None,
     curr: Annotated[
         Optional[str],
-        typer.Option("--curr", help="Current period, e.g. 'last-7d..now'."),
+        typer.Option("--curr", "-c", help="Current period, e.g. 'last-7d..now'."),
     ] = None,
     ref_start: Annotated[
         Optional[datetime],
@@ -158,11 +170,11 @@ def drift_command(
     ] = None,
     top_k: Annotated[
         Optional[int],
-        typer.Option("--top-k", help="Show only top K features."),
+        typer.Option("--top-k", "-k", help="Show only top K features."),
     ] = None,
     json_output: Annotated[
         bool,
-        typer.Option("--json", help="Output result as JSON."),
+        typer.Option("--json", "-j", help="Output result as JSON."),
     ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
     quiet: Annotated[bool, typer.Option("--quiet", "-q")] = False,

--- a/shapmonitor/cli/watch.py
+++ b/shapmonitor/cli/watch.py
@@ -13,7 +13,12 @@ from shapmonitor.cli._common import fail, setup_logging
 def watch_command(
     data_dir: Annotated[
         Path,
-        typer.Option(help="Directory containing SHAP logs.", envvar="SHAPMONITOR_DATA_DIR"),
+        typer.Option(
+            "--data-dir",
+            "-d",
+            help="Directory containing SHAP logs.",
+            envvar="SHAPMONITOR_DATA_DIR",
+        ),
     ] = Path("./shap_logs"),
     refresh: Annotated[
         float,
@@ -21,7 +26,7 @@ def watch_command(
     ] = 5.0,
     period: Annotated[
         Optional[str],
-        typer.Option(help="Lookback period, e.g. 'last-7d'."),
+        typer.Option("--period", "-p", help="Lookback period, e.g. 'last-7d'."),
     ] = "last-7d",
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
     quiet: Annotated[bool, typer.Option("--quiet", "-q")] = False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,48 @@ def test_report_summary_json(cli_fixtures):
     assert len(data["features"]) > 0
 
 
+def test_log_command_short_flags(cli_fixtures):
+    """log accepts short flags: -m, -d, -s, -j."""
+    result = runner.invoke(
+        app,
+        [
+            "log",
+            str(cli_fixtures["csv_path"]),
+            "-m",
+            str(cli_fixtures["model_path"]),
+            "-d",
+            str(cli_fixtures["shap_logs"]),
+            "-s",
+            "1.0",
+            "-j",
+        ],
+    )
+    assert result.exit_code == 0, f"log with short flags failed: {result.stdout}"
+    data = json.loads(result.stdout)
+    assert data["status"] == "ok"
+
+
+def test_report_summary_short_flags(cli_fixtures):
+    """report summary accepts -d, -p, -k, -j."""
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "summary",
+            "-d",
+            str(cli_fixtures["shap_logs"]),
+            "-p",
+            "last-30d",
+            "-k",
+            "3",
+            "-j",
+        ],
+    )
+    assert result.exit_code == 0, f"summary with short flags failed: {result.stdout}"
+    data = json.loads(result.stdout)
+    assert len(data["features"]) <= 3
+
+
 def test_report_drift_json(cli_fixtures):
     result = runner.invoke(
         app,
@@ -156,3 +198,22 @@ def test_report_drift_json(cli_fixtures):
     )
     # Drift may exit 1 if no data in one period — just check it doesn't crash
     assert result.exit_code in (0, 1), f"report drift crashed: {result.stdout}"
+
+
+def test_report_drift_short_flags(cli_fixtures):
+    """report drift accepts -d, -r, -c, -j."""
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "drift",
+            "-d",
+            str(cli_fixtures["shap_logs"]),
+            "-r",
+            "last-30d..last-15d",
+            "-c",
+            "last-15d..now",
+            "-j",
+        ],
+    )
+    assert result.exit_code in (0, 1), f"drift with short flags crashed: {result.stdout}"


### PR DESCRIPTION
## Summary
- Add short flag aliases to `shapmonitor` CLI subcommands for faster interactive use.
- `log`: `-d/--data-dir`, `-s/--sample-rate`, `-f/--feature-name`, `-j/--json`.
- `report summary`: `-d/--data-dir`, `-p/--period`, `-k/--top-k`, `-j/--json`.
- `report drift`: `-d/--data-dir`, `-r/--ref`, `-c/--curr`, `-k/--top-k`, `-j/--json`.
- `watch`: `-d/--data-dir`, `-p/--period`.
- `--model-version` and `--refresh` intentionally stay long-only to avoid collisions with `-v/--verbose` and cross-subcommand reuse of `-r`.
- All existing long-form flags remain unchanged (backwards compatible).

## Test plan
- [x] `poetry run pytest tests/test_cli.py` — 8 passed (5 existing + 3 new short-flag tests)
- [x] `shapmonitor log --help`, `report summary --help`, `report drift --help`, `watch --help` render short flags correctly